### PR TITLE
async generator force cleanup

### DIFF
--- a/miner/endpoints/text.py
+++ b/miner/endpoints/text.py
@@ -16,34 +16,32 @@ from miner.dependencies import get_worker_config
 
 from validator.utils.generic.generic_utils import async_chain
 from asyncio import TimeoutError as syncio_TimeoutError
+from contextlib import aclosing as async_ensure_close_context
 
 logger = get_logger(__name__)
 
 
 async def chat_completions(
-    decrypted_payload: payload_models.ChatPayload = Depends(
-        partial(decrypt_general_payload, payload_models.ChatPayload)
-    ),
+    decrypted_payload: payload_models.ChatPayload = Depends(partial(decrypt_general_payload, payload_models.ChatPayload)),
     config: Config = Depends(get_config),
     worker_config: WorkerConfig = Depends(get_worker_config),
 ) -> StreamingResponse:  # sourcery skip: raise-from-previous-error
-    
     logger.info("in chat_completions() got this far")
     logger.error("in chat_completions() got this far")
     print("in chat_completions() got this far")
-    #quit()
+    # quit()
+
     try:
-        generator = chat_stream(config.aiohttp_client, decrypted_payload, worker_config)
+        async with async_ensure_close_context(chat_stream(config.aiohttp_client, decrypted_payload, worker_config)) as generator:
+            try:
+                first_chunk = await generator.__anext__()
+            except syncio_TimeoutError:
+                first_chunk = None
 
-        try:
-            first_chunk = await generator.__anext__()
-        except syncio_TimeoutError:
-            first_chunk = None
-
-        if first_chunk is not None:
-            return StreamingResponse(async_chain(first_chunk, generator), media_type="text/event-stream") # type: ignore
-        logger.error("First chunk was None")
-        raise HTTPException(status_code=500, detail="Error in streaming text from the server")
+            if first_chunk is not None:
+                return StreamingResponse(async_chain(first_chunk, generator), media_type="text/event-stream")  # type: ignore
+            logger.error("First chunk was None")
+            raise HTTPException(status_code=500, detail="Error in streaming text from the server")
     except aiohttp.ClientError as e:
         logger.error(f"Error in streaming text from the server: {e}. ")
         raise HTTPException(status_code=500, detail=f"Error in streaming text from the server: {e}")


### PR DESCRIPTION
makes generator clean itself up on context exit and not just append an async task to the end of the async stack to clean up a resource that might already be gone